### PR TITLE
Remove 'libzip' dependency from documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,15 @@ system:
 
 Fedora 15:
 
-    sudo yum install binutils-devel bison glib2-devel libffi-devel libzip-devel
+    sudo yum install binutils-devel bison glib2-devel libffi-devel
 
 Ubuntu 10.10:
 
-    sudo apt-get install ecj libffi-dev binutils-dev libzip-dev libglib2.0-dev bison
+    sudo apt-get install ecj libffi-dev binutils-dev libglib2.0-dev bison
 
 Archlinux:
 
-    pacman -S eclipse-ecj classpath libzip libffi
+    pacman -S eclipse-ecj classpath libffi
 
 ### Building GNU Classpath
 


### PR DESCRIPTION
The `libzip` dependency has already been removed. Update the documentation accordingly.
